### PR TITLE
Update coat.R

### DIFF
--- a/R/coat.R
+++ b/R/coat.R
@@ -191,11 +191,14 @@ coat.fit <- function(formula, data, subset, na.action, weights, means = FALSE, t
 
 coat <- function(formula, data, id = NULL, meth = NULL, subset, na.action, weights, means = FALSE, type = c("ctree", "mob"),
                  replicates = FALSE, paired = FALSE, minsize = 10L, alpha = 0.05, minbucket = minsize, minsplit = NULL, ...){
+  cl <- match.call()
   
   if(replicates & (is.null(id) | is.null(meth))) stop("arguments id or meth are missing")
   
   data <- coat.reshape(formula, data, id = id, meth = meth, replicates = replicates, paired = paired)
   fit <- coat.fit(formula, data, replicates = replicates, paired = paired, type = type, means = means, na.action = na.action,
                   minsize = minsize, minsplit = minsplit, alpha = alpha, ...)
+
+  fit$info$call <- cl
   return(fit)
 }


### PR DESCRIPTION
The call of coat() is now saved and overwrites the call of coat.fit() to enable the print()-funktion to display this call correctly. Needs to be approved for all cases of COAT. Also needs to be adapted to include "means" in the model formula, if used.